### PR TITLE
Eliminate the need to set './node_modules/.bin' in your '$PATH'

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ yarn install
 stt # Open this folder in Sublime Text
 ```
 
-Make sure you have `./node_modules/.bin` in your `$PATH`! This way you can run this:
+Now you can run this:
 
 ```bash
-eslint lib
-webpack-dev-server
+yarn run lint
+yarn run dev
 ```
 
 Once a file has been updated in Sublime, you can run it with:

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "1.0.0",
   "description": "Starting code for First JavaScript ES6 lecture",
   "main": "index.js",
+  "scripts": {
+    "lint": "eslint lib",
+    "dev": "webpack-dev-server"
+  },
   "repository": "https://github.com/lewagon/webpack-boilerplate",
   "author": "ssaunier",
   "license": "MIT",


### PR DESCRIPTION
By adding the commands to "scripts", no need for './node_modules/.bin' to be in your '$PATH'
Do simply
`yarn / npm run 'script_name'`
